### PR TITLE
[Issue-41] Use commas for currencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "buffer": "^6.0.3",
     "chart.js": "^3.5.0",
     "classnames": "^2.3.1",
-    "comma-number": "^2.1.0",
     "core-js": "^3.15.2",
     "cross-env": "^7.0.3",
     "crypto-browserify": "^3.12.0",

--- a/src/components/elements/AssetCard.svelte
+++ b/src/components/elements/AssetCard.svelte
@@ -1,12 +1,12 @@
 <script>
-import commaNumber from 'comma-number';
-
 export let assetName = 'Alchemix Asset';
 export let assetTicker = 'alASS';
 export let assetPrice = 0.01;
 export let currency = '$';
 export let assetIcon = 'icon.png';
 export let assetColor = 'bronze2';
+
+const formattedNumber = new Intl.NumberFormat().format(assetPrice.toFixed(2));
 </script>
 
 <div class="flex flex-col w-80 rounded-3xl bg-grey10 bg-opacity-30 border border-lightgrey20 p-8 pb-0">
@@ -14,7 +14,7 @@ export let assetColor = 'bronze2';
   <p class="text-3xl">{assetTicker}</p>
   <p>
     <span class="text-base opacity-50">{currency}</span>
-    <span class="text-3xl">{commaNumber(assetPrice.toFixed(2))}</span>
+    <span class="text-3xl">{formattedNumber}</span>
   </p>
   <img
     src="images/asset-card-icons/{assetIcon}"


### PR DESCRIPTION
# Summary 

Instead of no-commas in currencies
<img width="451" alt="Screen Shot 2021-08-29 at 4 23 48 PM" src="https://user-images.githubusercontent.com/88438831/131255258-0f3ae86b-e616-47bf-ab88-54c468908655.png">

Have commas in currencies
<img width="1016" alt="Screen Shot 2021-08-29 at 4 38 42 PM" src="https://user-images.githubusercontent.com/88438831/131255265-c3ac4325-f0a8-49ed-86c0-eaa3ad95f23a.png">

