### PR TITLE
Remove newlines, let developers use wordwrap instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ yarn install
 
 Fill the `.env` file with the required secrets.
 
-Start local development server using `yarn dev` to fetch latest contract artifacts, or use `yarn dev:noabi` to skip
-that.
+Start local development server using `yarn dev` to fetch latest contract artifacts, or use `yarn dev:noabi` to skip that.
 
 The app should be accessible on [localhost:5005](http://localhost:5005) by default.
 
@@ -27,8 +26,7 @@ This repository is using two main branches for deployments:
 - The [production deployment](https://alchemix.fi/) is built using `prod` branch codebase
 - The [staging deployment](https://staging.alchemix.fi/) is built using `staging` branch codebase
 
-New branches, when pushed, will also be built using our Vercel CI/CD pipeline, so minimize unneccessary pushes to
-tracked branches.
+New branches, when pushed, will also be built using our Vercel CI/CD pipeline, so minimize unneccessary pushes to tracked branches.
 
 In general the process to contribute to the codebase looks like this:
 
@@ -38,8 +36,7 @@ In general the process to contribute to the codebase looks like this:
 
 With the next deployment cycle, `staging` and all changes in it will be merged into `prod`.
 
-Use descriptive language in your commit messages. Nobody likes to chase down changes to understand what is supposed to
-be changed.
+Use descriptive language in your commit messages. Nobody likes to chase down changes to understand what is supposed to be changed.
 
 ### Codestyle
 
@@ -49,8 +46,7 @@ To make it easier for all contributors, please respect the codestyle rules.
 
 #### Webstorm
 
-Open Webstorm settings and navigate to `Preferences/Languages & Frameworks/JavaScript/Prettier`, select the Prettier
-install from the local `node_modules` directory, add `svelte` to the glob pattern and enable `Run on save for files`.
+Open Webstorm settings and navigate to `Preferences/Languages & Frameworks/JavaScript/Prettier`, select the Prettier install from the local `node_modules` directory, add `svelte` to the glob pattern and enable `Run on save for files`.
 
 Source: [prettier.io docs](https://prettier.io/docs/en/webstorm.html)
 
@@ -58,8 +54,7 @@ Source: [prettier.io docs](https://prettier.io/docs/en/webstorm.html)
 
 ##### Using Svelte extension (recommended)
 
-Install the `svelte-vscode` extension either through the marketplace, or by using the quick open command and
-pasting `ext install JamesBirtles.svelte-vscode`. Make sure VS Code settings includes
+Install the `svelte-vscode` extension either through the marketplace, or by using the quick open command and pasting `ext install JamesBirtles.svelte-vscode`. Make sure VS Code settings includes
 
 ```json
 {
@@ -73,8 +68,7 @@ Source: [svelte-vscode marketplace](https://marketplace.visualstudio.com/items?i
 
 ##### Using Prettier extension
 
-Install the `prettier-vscode` extension either through the marketplace, or by using the quick open command and
-pasting `ext install esbenp.prettier-vscode`. Make sure VS Code settings includes
+Install the `prettier-vscode` extension either through the marketplace, or by using the quick open command and pasting `ext install esbenp.prettier-vscode`. Make sure VS Code settings includes
 
 ```json
 {


### PR DESCRIPTION
It is cleaner to use word wrap to read MD files instead of formatting the MD file beforehand.