### PR TITLE
Fix balance comparison in Repay.svelte and add staking pool address for alETH arbitrum

### DIFF
--- a/src/components/composed/Modals/vaults/Repay.svelte
+++ b/src/components/composed/Modals/vaults/Repay.svelte
@@ -156,7 +156,7 @@
     currentSelectedVaultType = value.detail.vault;
     currentSelectedUnderlyingTokenSymbol = useTokenListForVaultType(currentSelectedVaultType, [
       $vaultsStore,
-    ]).filter((entry) => entry.balance.gt(BigNumber.from(0)))[0].symbol;
+    ]).filter((entry) => entry.balance.gte(BigNumber.from(0)))[0].symbol;
   };
 </script>
 

--- a/src/stores/stakingPools.js
+++ b/src/stores/stakingPools.js
@@ -43,6 +43,10 @@ export const additionalTokens = [
   },
   {
     network: '0xa4b1',
+    address: '0x17573150d67d820542EFb24210371545a4868B03',
+  },
+  {
+    network: '0xa4b1',
     address: '0x870d36B8AD33919Cc57FFE17Bb5D3b84F3aDee4f',
   },
   {


### PR DESCRIPTION
This pull request addresses an issue with the DebtCard selectors 

Problems:

In the Repay component, when switching between alUSD & alETH debt, the default available currency for repayment does not change. This issue is on all networks


In the Liquidation component, while connected to arbitrum, if the user tries to select the alETH DebtCard an error is thrown and the UI becomes unresponsive to inputs. This issue only exist on arbitrum network

Solutions

The first commit fixes a balance comparison issue in the Repay.svelte file. This allows the default currency to change even when user has a 0 balance in their wallet of the repayment currencies

The second commit adds a staking pool address for alETH arbitrum. This solves the error by adding the alETH token to the balancesStore on arbitrum