### PR TITLE
Fix permanent loading state on the transmuter page

### DIFF
--- a/src/views/Transmuter.svelte
+++ b/src/views/Transmuter.svelte
@@ -41,7 +41,7 @@
     .filter((elm) => elm !== undefined)
     .reduce((acc, value) => acc.concat(value), [])
     .map((_transmuterData) => {
-      if (_transmuterData && $balancesStore.length) {
+      if (_transmuterData && $balancesStore.length > 0) {
         const synthTokenData = getTokenDataFromBalances(_transmuterData.synthAddress, [$balancesStore]);
         const underlyingTokenData = getTokenDataFromBalances(_transmuterData.underlyingTokenAddress, [
           $balancesStore,
@@ -126,7 +126,7 @@
     });
 
     Promise.all([...transmuterSelection]).then(() => {
-      transmutersLoading = balancesStore.length ? false : true; // if balances are not loaded, keep loading
+      transmutersLoading = balancesStore.length > 0 ? false : true; // if balances are not loaded, keep loading
     });
   };
 

--- a/src/views/Transmuter.svelte
+++ b/src/views/Transmuter.svelte
@@ -41,7 +41,7 @@
     .filter((elm) => elm !== undefined)
     .reduce((acc, value) => acc.concat(value), [])
     .map((_transmuterData) => {
-      if (_transmuterData) {
+      if (_transmuterData && $balancesStore.length) {
         const synthTokenData = getTokenDataFromBalances(_transmuterData.synthAddress, [$balancesStore]);
         const underlyingTokenData = getTokenDataFromBalances(_transmuterData.underlyingTokenAddress, [
           $balancesStore,
@@ -50,6 +50,10 @@
         // const tokenPrice = $global.tokenPrices.find(
         //   (token) => token.address.toLowerCase() === synthTokenData.address.toLowerCase(),
         // )?.price;
+        if (!underlyingTokenData && !synthTokenData) {
+          return;
+        }
+
         const tokenPrice =
           $tokenPriceStore[underlyingTokenData.address.toLowerCase()][
             $settings.baseCurrency.symbol.toLowerCase()
@@ -122,7 +126,7 @@
     });
 
     Promise.all([...transmuterSelection]).then(() => {
-      transmutersLoading = false;
+      transmutersLoading = balancesStore.length ? false : true; // if balances are not loaded, keep loading
     });
   };
 


### PR DESCRIPTION
This pull request fixes a conditional check in the Transmuter.svelte file to prevent the perma-load state. 

Checks for the $balancesStore to contain data before attempting to derive UI elements from it.

Trying to use $balancesStore before it has been populated in during the initialization causes an error, leaving the UI in a permanent loading state