### PR TITLE
Fix wstETH deposit on Arbitrum

### DIFF
--- a/src/stores/v2/vaultActions.ts
+++ b/src/stores/v2/vaultActions.ts
@@ -111,7 +111,7 @@ export async function deposit(
       // @dev this is a temporary fix until we can properly refactor the vaults
       tokenAddress !== '0xa258C4606Ca8206D8aA700cE2143D7db854D168c' &&
       tokenAddress !== '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0' &&
-      tokenAddress !== '0x5979D7b546E38E414F7E9822514be443A4800529' &&
+      tokenAddress !== '0x5979D7b546E38E414F7E9822514be443A4800529' && // wstETH arbitrum
       gatewayIndexCheck >= 0 &&
       gatewayCheck[gatewayIndexCheck] !== undefined
     ) {

--- a/src/stores/v2/vaultActions.ts
+++ b/src/stores/v2/vaultActions.ts
@@ -132,7 +132,7 @@ export async function deposit(
 
       setPendingWallet();
 
-      const tx = (await gatewayInstance.deposit(
+      const tx = (await alchemistInstance.deposit(
         staticToken,
         amountYield,
         userAddressStore,

--- a/src/stores/v2/vaultActions.ts
+++ b/src/stores/v2/vaultActions.ts
@@ -111,6 +111,7 @@ export async function deposit(
       // @dev this is a temporary fix until we can properly refactor the vaults
       tokenAddress !== '0xa258C4606Ca8206D8aA700cE2143D7db854D168c' &&
       tokenAddress !== '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0' &&
+      tokenAddress !== '0x5979D7b546E38E414F7E9822514be443A4800529' &&
       gatewayIndexCheck >= 0 &&
       gatewayCheck[gatewayIndexCheck] !== undefined
     ) {
@@ -132,7 +133,7 @@ export async function deposit(
 
       setPendingWallet();
 
-      const tx = (await alchemistInstance.deposit(
+      const tx = (await gatewayInstance.deposit(
         staticToken,
         amountYield,
         userAddressStore,


### PR DESCRIPTION
This pull request updates the deposit function to use the alchemistInstance instead of the gatewayInstance. This change ensures that the correct instance is used for the deposit operation, fixing an error 'gatewayInstance.deposit is not a function'